### PR TITLE
[WIP] Fix for footnotes being confused for link references.

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -468,7 +468,6 @@ static void process_footnotes(cmark_parser *parser) {
   while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
     cur = cmark_iter_get_node(iter);
     if (ev_type == CMARK_EVENT_EXIT && cur->type == CMARK_NODE_FOOTNOTE_DEFINITION) {
-      cmark_node_unlink(cur);
       cmark_footnote_create(map, cur);
     }
   }
@@ -515,8 +514,10 @@ static void process_footnotes(cmark_parser *parser) {
     qsort(map->sorted, map->size, sizeof(cmark_map_entry *), sort_footnote_by_ix);
     for (unsigned int i = 0; i < map->size; ++i) {
       cmark_footnote *footnote = (cmark_footnote *)map->sorted[i];
-      if (!footnote->ix)
+      if (!footnote->ix) {
+        cmark_node_unlink(footnote->node);
         continue;
+      }
       cmark_node_append_child(parser->root, footnote->node);
       footnote->node = NULL;
     }

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1141,6 +1141,14 @@ noMatch:
       !opener->inl_text->next->next) {
     cmark_chunk *literal = &opener->inl_text->next->as.literal;
     if (literal->len > 1 && literal->data[0] == '^') {
+
+      // Great. We're definitely in a footnote.
+      // Before we got this far, the `handle_close_bracket` function may have
+      // advanced the current state beyond our footnote's actual closing
+      // bracket, ie if it went looking for a `link_label`.
+      // Let's just rewind the subject's position:
+      subj->pos = initial_pos;
+
       inl = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
       inl->as.literal = cmark_chunk_dup(literal, 1, literal->len - 1);
       inl->start_line = inl->end_line = subj->line;

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -645,16 +645,15 @@ Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
 ## Footnotes
 
 ```````````````````````````````` example
-This is some text![^1]. Other text.[^footnote].
+This is some text![^1]. Other text.[^citation].
 
-Here's a thing[^other-note].
+This line tests that "w" doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the `][`s, the footnotes won't be confused for a link reference (currently broken).[^citation][^1] [^widely-cited]
 
-And another thing[^codeblock-note].
+Here's another thing[^codeblock-note]. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]
 
 This doesn't have a referent[^nope].
 
-
-[^other-note]:       no code block here (spaces are stripped away)
+[^widely-cited]:       no code block here (spaces are stripped away). This footnote is cited three times, and so we should see three backrefs.
 
 [^codeblock-note]:
         this is now a code block (8 spaces indentation)
@@ -663,26 +662,28 @@ This doesn't have a referent[^nope].
 
 [^nested]: Footnotes can be nested.
 
-Hi!
+Hi! Footnote _definitions_ should be removed from the text, and reinserted at the bottom.
 
-[^footnote]:
+[^citation]:
     > Blockquotes can be in a footnote.
 
         as well as code blocks
 
     or, naturally, simple paragraphs.
 
-[^unused]: This is unused.
+[^sphinx-of-black-quartz_judge-my-vow-0123456789]: This works.
+
+[^unused]: This is unused, and will be removed.
 .
 <p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
-<p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>.</p>
-<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
+<p>This line tests that &quot;w&quot; doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the <code>][</code>s, the footnotes won't be confused for a link reference (currently broken).<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup> [^widely-cited]</p>
+<p>Here's another thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]</p>
 <p>This doesn't have a referent[^nope].</p>
-<p>Hi!</p>
+<p>Hi! Footnote <em>definitions</em> should be removed from the text, and reinserted at the bottom.</p>
 <section class="footnotes">
 <ol>
 <li id="fn1">
-<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn5" id="fnref5">5</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
+<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn2">
 <blockquote>
@@ -693,15 +694,12 @@ Hi!
 <p>or, naturally, simple paragraphs. <a href="#fnref2" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn3">
-<p>no code block here (spaces are stripped away) <a href="#fnref3" class="footnote-backref">↩</a></p>
-</li>
-<li id="fn4">
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
-<a href="#fnref4" class="footnote-backref">↩</a>
+<a href="#fnref3" class="footnote-backref">↩</a>
 </li>
-<li id="fn5">
-<p>Footnotes can be nested. <a href="#fnref5" class="footnote-backref">↩</a></p>
+<li id="fn4">
+<p>Footnotes can be nested. <a href="#fnref4" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -645,42 +645,45 @@ Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
 ## Footnotes
 
 ```````````````````````````````` example
-This is some text![^1]. Other text.[^footnote].
+This is some text![^1]. Other text.[^citation].
 
-Here's a thing[^other-note][^footnote].
+This line tests that "w" doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the `][`s, the footnotes won't be confused for a link reference.[^citation][^1] [^widely-cited]
 
-And another thing[^codeblock-note].
+Here's another thing[^codeblock-note]. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]
 
 This doesn't have a referent[^nope].
 
-
-[^other-note]:       no code block here (spaces are stripped away)
+[^widely-cited]:       no code block here (spaces are stripped away). This footnote is cited three times, and so we should see three backrefs.
 
 [^codeblock-note]:
         this is now a code block (8 spaces indentation)
 
-[^1]: Some *bolded* footnote definition.
+[^1]: Some *bolded* footnote definition.[^nested]
 
-Hi!
+[^nested]: Footnotes can be nested.
 
-[^footnote]:
+Hi! Footnote _definitions_ should be removed from the text, and reinserted at the bottom.
+
+[^citation]:
     > Blockquotes can be in a footnote.
 
         as well as code blocks
 
     or, naturally, simple paragraphs.
 
-[^unused]: This is unused.
+[^sphinx-of-black-quartz_judge-my-vow-0123456789]: This works.
+
+[^unused]: This is unused, and will be removed.
 .
 <p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
-<p>Here's a thing. Footnotes can be referenced more than once; even if there's not a space between the <code>][</code>s, the footnotes won't be confused for a link reference.<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup><sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
-<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
+<p>This line tests that &quot;w&quot; doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the <code>][</code>s, the footnotes won't be confused for a link reference.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup><sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup> [^widely-cited]</p>
+<p>Here's another thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]</p>
 <p>This doesn't have a referent[^nope].</p>
-<p>Hi!</p>
+<p>Hi! Footnote <em>definitions</em> should be removed from the text, and reinserted at the bottom.</p>
 <section class="footnotes">
 <ol>
 <li id="fn1">
-<p>Some <em>bolded</em> footnote definition. <a href="#fnref1" class="footnote-backref">↩</a></p>
+<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fnnested" id="fnrefnested">nested</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn2">
 <blockquote>
@@ -691,12 +694,9 @@ Hi!
 <p>or, naturally, simple paragraphs. <a href="#fnref2" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn3">
-<p>no code block here (spaces are stripped away) <a href="#fnref3" class="footnote-backref">↩</a></p>
-</li>
-<li id="fn4">
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
-<a href="#fnref4" class="footnote-backref">↩</a>
+<a href="#fnref3" class="footnote-backref">↩</a>
 </li>
 </ol>
 </section>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -647,7 +647,7 @@ Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
 ```````````````````````````````` example
 This is some text![^1]. Other text.[^footnote].
 
-Here's a thing[^other-note].
+Here's a thing[^other-note][^footnote].
 
 And another thing[^codeblock-note].
 
@@ -673,7 +673,7 @@ Hi!
 [^unused]: This is unused.
 .
 <p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
-<p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>.</p>
+<p>Here's a thing. Footnotes can be referenced more than once; even if there's not a space between the <code>][</code>s, the footnotes won't be confused for a link reference.<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup><sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
 <p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
 <p>This doesn't have a referent[^nope].</p>
 <p>Hi!</p>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -659,7 +659,9 @@ This doesn't have a referent[^nope].
 [^codeblock-note]:
         this is now a code block (8 spaces indentation)
 
-[^1]: Some *bolded* footnote definition.
+[^1]: Some *bolded* footnote definition.[^nested]
+
+[^nested]: Footnotes can be nested.
 
 Hi!
 
@@ -680,7 +682,7 @@ Hi!
 <section class="footnotes">
 <ol>
 <li id="fn1">
-<p>Some <em>bolded</em> footnote definition. <a href="#fnref1" class="footnote-backref">↩</a></p>
+<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn5" id="fnref5">5</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn2">
 <blockquote>
@@ -697,6 +699,9 @@ Hi!
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
 <a href="#fnref4" class="footnote-backref">↩</a>
+</li>
+<li id="fn5">
+<p>Footnotes can be nested. <a href="#fnref5" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
When two footnote references are adjacent, the handle_close_bracket
function will first try to match the closing bracket to a link
reference. Now we reset the subject's state, so that the parser
correctly picks up both footnote references.